### PR TITLE
Original Dcc.export_asset() is now called _setup_asset_export_task().

### DIFF
--- a/dcckit/dblender.py
+++ b/dcckit/dblender.py
@@ -114,7 +114,7 @@ class BlenderDcc(dcore.Dcc):
         return tree_root
 
     def export_asset(self, asset_name, destination_folder="./", file_format="FBX", options={}):
-        objects_to_export, full_path = super().export_asset(asset_name, destination_folder=destination_folder,
+        objects_to_export, full_path =  self._setup_export_asset_task(asset_name, destination_folder=destination_folder,
                                                             file_format=file_format, options=options)
 
         # This line is needed to remove any unwanted '.[0-9][0-9][0-9]' string present in asset name due to Blender handling of duplicated collections name

--- a/dcckit/dcore.py
+++ b/dcckit/dcore.py
@@ -343,7 +343,7 @@ class Dcc:
         """ Override this in child class for specific DCCs"""
         return SceneNode()
 
-    def export_asset(self, asset_name, destination_folder="./", file_format="FBX", options={}):
+    def _setup_export_asset_task(self, asset_name, destination_folder="./", file_format="FBX", options={}):
         """
         Override this in child class for specific DCCs
         It export a given asset from the scene to a file
@@ -394,6 +394,10 @@ class Dcc:
 
         print(f"Exporting {asset_to_export.name} with name {asset_name} in {destination_folder}")
         return objects_to_export, full_path
+
+    def export_asset(self, asset_name, destination_folder="./", file_format="FBX", options={}):
+        raise NotImplementedError("'export_asset()' method must be implemented in a Dcc child class."
+                                  "\nA call to '_setup_export_asset_task()' must be included.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Dcc.export_asset() is still there but now it just raise a NotImplementedError.
BlenderDcc.export_asset() doesn't call super().export_asset() anymore but
super()._setup_asset_export_task()